### PR TITLE
fixed pahole.py to support pahole version 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IMPORTANT MESSAGE TO REPRO THIS CODE
 
-You must make sure you use the Ubuntu 18.04.6 LTS but **DO NOT DOWNLOAD UPDATES** when you install the OS. Make sure you use [this](https://releases.ubuntu.com/18.04/ubuntu-18.04.6-desktop-amd64.iso) iso.
+You must make sure you use the Ubuntu 18.04.6 LTS but **DO NOT DOWNLOAD UPDATES** when you install the OS. Make sure you use [this](https://releases.ubuntu.com/18.04/ubuntu-18.04.6-desktop-amd64.iso) iso. Make sure you are in your `$HOME` directory when cloning this repo or change `S2EDIR` in `./s2e/s2e_activate:30` accordingly.
 
 # KOOBE
 Towards Facilitating Exploit Generation of Kernel Out-Of-Bounds Write Vulnerabilities

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# IMPORTANT MESSAGE TO REPRO THIS CODE
+
+You must make sure you use the Ubuntu 18.04.6 LTS but <div color="red">**DO NOT DOWNLOAD UPDATES**</div> when you install the OS. Make sure you use [this](https://releases.ubuntu.com/18.04/ubuntu-18.04.6-desktop-amd64.iso) iso.
+
 # KOOBE
 Towards Facilitating Exploit Generation of Kernel Out-Of-Bounds Write Vulnerabilities
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IMPORTANT MESSAGE TO REPRO THIS CODE
 
-You must make sure you use the Ubuntu 18.04.6 LTS but <div color="red">**DO NOT DOWNLOAD UPDATES**</div> when you install the OS. Make sure you use [this](https://releases.ubuntu.com/18.04/ubuntu-18.04.6-desktop-amd64.iso) iso.
+You must make sure you use the Ubuntu 18.04.6 LTS but **DO NOT DOWNLOAD UPDATES** when you install the OS. Make sure you use [this](https://releases.ubuntu.com/18.04/ubuntu-18.04.6-desktop-amd64.iso) iso.
 
 # KOOBE
 Towards Facilitating Exploit Generation of Kernel Out-Of-Bounds Write Vulnerabilities

--- a/aeg-analysis/aeg/report.py
+++ b/aeg-analysis/aeg/report.py
@@ -130,8 +130,11 @@ class Report:
                         continue
                     funCall = sym.name
                     target = inst.address
-                    fun_addr = int(inst.op_str, 16)
-                    sym = self._kernel.find_symbol(fun_addr, fuzzy=False)
+                    try:
+						fun_addr = int(inst.op_str, 16)
+                    except:
+						continue
+					sym = self._kernel.find_symbol(fun_addr, fuzzy=False)
                     retType = self.getType(sym.name)
                     self._funCall = sym.name
                     break

--- a/aeg-analysis/requirements.txt
+++ b/aeg-analysis/requirements.txt
@@ -1,3 +1,3 @@
-angr
+angr<=8.6.0
 psutil
 pexpect

--- a/aeg-analysis/requirements.txt
+++ b/aeg-analysis/requirements.txt
@@ -1,3 +1,3 @@
-angr<=8.6.0
+angr<9.0
 psutil
 pexpect

--- a/build.sh
+++ b/build.sh
@@ -12,5 +12,5 @@ source common.sh
 
 # build kernel
 sudo chmod ugo+r /boot/vmlinu*
-/bin/bash -c "source ${VIRTUAL_ENV} && cd ${S2EDIR} && s2e image_build debian-9.2.1-x86_64"
+/bin/bash -c "source ${VIRTUAL_ENV} && cd ${S2EDIR} && s2e image_build debian-9.2.1-x86_64 --gui"
 

--- a/s2e/s2e_activate
+++ b/s2e/s2e_activate
@@ -27,7 +27,7 @@ s2e_deactivate() {
 # unset irrelvant variables
 s2e_deactivate nondestructive
 
-S2EDIR="/home/wchen130/workplace/KOOBE/s2e"
+S2EDIR="$HOME/KOOBE/s2e"
 export S2EDIR
 
 if [ -z "${S2E_ENV_DISABLE_PROMPT-}" ] ; then

--- a/s2e/source/guest-images/Linux/docker/Dockerfile.x86_64
+++ b/s2e/source/guest-images/Linux/docker/Dockerfile.x86_64
@@ -44,6 +44,7 @@ RUN                                                                             
     apt-get clean && \
     apt-file update || true
 
+RUN git config --global http.sslVerify false
 
 RUN \
     git clone git://sourceware.org/git/systemtap.git && \

--- a/s2e/source/guest-images/Linux/docker/Dockerfile.x86_64
+++ b/s2e/source/guest-images/Linux/docker/Dockerfile.x86_64
@@ -26,15 +26,23 @@ FROM debian:9.3
 
 MAINTAINER Vitaly Chipounov <vitaly@cyberhaven.io>
 
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+RUN sed -i 's|security.debian.org|archive.debian.org/debian-security/|g' /etc/apt/sources.list
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
+
+#RUN deb http://archive.debian.org/debian/ stretch-updates main contrib non-free
+#RUN deb http://archive.debian.org/debian-security/ stretch/updates main contrib non-free
+
+
 RUN                                                                             \
-    apt-get update &&                                                           \
+    apt-get update  &&                                                          \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends   \
     sudo apt-file texinfo flex bison patch python unzip git bc                  \
     bzip2 wget less nano g++ gcc file libc6-dev make                            \
     fakeroot build-essential devscripts libncurses5-dev                         \
     libdw-dev elfutils gettext && \
     apt-get clean && \
-    apt-file update
+    apt-file update || true
 
 
 RUN \

--- a/s2e/source/s2e/scripts/determine_clang_binary_suffix.py
+++ b/s2e/source/s2e/scripts/determine_clang_binary_suffix.py
@@ -29,7 +29,7 @@ Note: This script is only really meant to be used by the S2E Makefile. It has
 no real use outside of this.
 """
 
-import platform
+import distro as platform
 import sys
 
 

--- a/s2e/source/s2e/scripts/determine_clang_binary_suffix.py
+++ b/s2e/source/s2e/scripts/determine_clang_binary_suffix.py
@@ -29,7 +29,7 @@ Note: This script is only really meant to be used by the S2E Makefile. It has
 no real use outside of this.
 """
 
-import distro as platform
+import distro as dis
 import sys
 
 
@@ -79,7 +79,7 @@ def _get_ubuntu_version(version_string):
 
 def main():
     """The main function."""
-    distro, version, _ = platform.linux_distribution()
+    [distro, version] = [dis.id(), dis.version()]
 
     clang_ver_to_download = None
     if distro.lower() == 'debian':

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ sudo apt-get install python3-dev libffi-dev build-essential virtualenvwrapper de
 
 source common.sh
 
-virtualenv ${KOOBE} --python=$(which python3)
+virtualenv ${KOOBE} --python=$(which python3.8)
 # install s2e-env
 /bin/bash -c "source ${VIRTUAL_ENV} && cd s2e/source/s2e-env && pip install ."
 echo "S2EDIR=\"${S2EDIR}\"" >> $VIRTUAL_ENV


### PR DESCRIPTION
It seems `pahole.py` doesn't work with Linux kernel 5.15 and pahole version 1.21.
This seems to fix it.

NOTE: Needs to be checked with the `pahole` version this project war originally run on, but 1.21 is the latest version of Ubuntu 18.04